### PR TITLE
Fix werkzeug deprecation warning

### DIFF
--- a/flask_prom/__init__.py
+++ b/flask_prom/__init__.py
@@ -2,7 +2,7 @@ import time
 from flask import request
 from prometheus_client import Counter, Histogram
 from prometheus_client import start_http_server, make_wsgi_app
-from werkzeug.wsgi import DispatcherMiddleware
+from werkzeug.wsgi.middleware.dispatcher import DispatcherMiddleware
 
 FLASK_REQUEST_ENDPOINT_SENTINEL = "-"
 


### PR DESCRIPTION
I am getting this instead:

> ./env/lib/python3.7/site-packages/flask_prom/__init__.py:5: DeprecationWarning: The import 'werkzeug.wsgi.DispatcherMiddleware' is deprecated and will be removed in Werkzeug 1.0. Use 'from werkzeug.wsgi.middleware.dispatcher import DispatcherMiddleware' instead.                                                                                                                                                                                                                                    
  from werkzeug.wsgi import DispatcherMiddleware 